### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=James Blakey-Milner, Atlantis Specialist Technologies <james@atlantisgrou
 maintainer=James Blakey-Milner, <james@atlantisgroup.co.za>
 sentence=This library allows for use of the hardware CAN port on the CAN485 board
 paragraph=This library allows for use of the hardware CAN port on the CAN485 board
-category=Communications
+category=Communication
 url=https://github.com/Atlantis-Specialist-Technologies/CAN485
 architectures=avr


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'Communications' in library AST_CAN is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format