### PR TITLE
Prescaler support

### DIFF
--- a/src/ASTCanLib.cpp
+++ b/src/ASTCanLib.cpp
@@ -10,9 +10,6 @@
 #include "ASTCanLib.h"
 
 void canInit(long baud){
-  // Clock prescaler
-  CLKPR  = ( 1 << CLKPCE );          // Set Clock Prescaler change enable
-  CLKPR  = 0x00;
   // Setup ports
   DDRB  |= (1<<DDB1)|(1<<DDB4);
   DDRD  |= (1<<DDD5);                // TxCan

--- a/src/can_lib.c
+++ b/src/can_lib.c
@@ -63,6 +63,7 @@
 U8 can_init(U8 mode,long baud)
 {
   switch(baud){
+#if F_CPU == 16000000UL
     case 1000000: // TQ=0.125
       CANBT1 = 0x02;
       CANBT2 = 0x04;
@@ -93,6 +94,121 @@ U8 can_init(U8 mode,long baud)
       CANBT2 = 0x0C;
       CANBT3 = 0x37;
       break;
+#elif F_CPU == 12000000UL
+    case 1000000: // TQ=0.083333
+      CANBT1 = 0x00;
+      CANBT2 = 0x08;
+      CANBT3 = 0x24;
+      break;
+    case 500000: // TQ=0.250
+      CANBT1 = 0x04;
+      CANBT2 = 0x04;
+      CANBT3 = 0x13;
+      break;
+    case 250000: // TQ=0.250
+      CANBT1 = 0x04;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x37;
+      break;
+    case 200000: // TQ=0.250
+      CANBT1 = 0x04;
+      CANBT2 = 0x0E;
+      CANBT3 = 0x4B;
+      break;
+    case 125000: // TQ=0.500
+      CANBT1 = 0x0A; 
+      CANBT2 = 0x0C;
+      CANBT3 = 0x37;
+      break;
+    case 100000: // TQ=0.500
+      CANBT1 = 0x0A;
+      CANBT2 = 0x0E;
+      CANBT3 = 0x4B;
+      break;
+#elif F_CPU == 8000000UL
+    case 1000000: // TQ=0.125
+      CANBT1 = 0x00;
+      CANBT2 = 0x04;
+      CANBT3 = 0x12;
+      break;
+    case 500000: // TQ=0.250
+      CANBT1 = 0x02;
+      CANBT2 = 0x04;
+      CANBT3 = 0x13;
+      break;
+    case 250000: // TQ=0.250
+      CANBT1 = 0x02;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x37;
+      break;
+    case 200000: // TQ=0.250
+      CANBT1 = 0x02;
+      CANBT2 = 0x0E;
+      CANBT3 = 0x4B;
+      break;
+    case 125000: // TQ=0.500
+      CANBT1 = 0x06;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x37;
+      break;
+    case 100000: // TQ=0.625
+      CANBT1 = 0x08;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x37;
+      break;
+#elif F_CPU == 6000000UL
+    case 500000: // TQ=0.166666
+      CANBT1 = 0x00;
+      CANBT2 = 0x08;
+      CANBT3 = 0x24;
+      break;
+    case 250000: // TQ=0.333333
+      CANBT1 = 0x02;
+      CANBT2 = 0x08;
+      CANBT3 = 0x25;
+      break;
+    case 200000: // TQ=0.333333
+      CANBT1 = 0x02;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x35;
+      break;
+    case 125000: // TQ=0.500
+      CANBT1 = 0x04;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x37;
+      break;
+    case 100000: // TQ=0.500
+      CANBT1 = 0x04;
+      CANBT2 = 0x0E;
+      CANBT3 = 0x4B;
+      break;
+#elif F_CPU == 4000000UL
+    case 500000: // TQ=0.250
+      CANBT1 = 0x00;
+      CANBT2 = 0x04;
+      CANBT3 = 0x12;
+      break;
+    case 250000: // TQ=0.250
+      CANBT1 = 0x00;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x36;
+      break;
+    case 200000: // TQ=0.250
+      CANBT1 = 0x00;
+      CANBT2 = 0x0E;
+      CANBT3 = 0x4A;
+      break;
+    case 125000: // TQ=0.500
+      CANBT1 = 0x02;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x37;
+      break;
+    case 100000: // TQ=0.500
+      CANBT1 = 0x02;
+      CANBT2 = 0x0E;
+      CANBT3 = 0x4B;
+      break;
+#endif
     default:
       return(0);
   }

--- a/src/can_lib.c
+++ b/src/can_lib.c
@@ -63,35 +63,35 @@
 U8 can_init(U8 mode,long baud)
 {
   switch(baud){
-    case 100000:
-      CANBT1 = 0x12;
+    case 1000000: // TQ=0.125
+      CANBT1 = 0x02;
+      CANBT2 = 0x04;
+      CANBT3 = 0x13;
+      break;
+    case 500000: // TQ=0.250
+      CANBT1 = 0x06;
+      CANBT2 = 0x04;
+      CANBT3 = 0x13;
+      break;
+    case 250000: // TQ=0.250
+      CANBT1 = 0x06;
       CANBT2 = 0x0C;
       CANBT3 = 0x37;
       break;
-    case 125000:
-      CANBT1 = 0x0E;
-      CANBT2 = 0x0C;
-      CANBT3 = 0x37;
-      break;
-    case 200000:
+    case 200000: // TQ=0.3125
       CANBT1 = 0x08;
       CANBT2 = 0x0C;
       CANBT3 = 0x37;
       break;
-    case 250000:
-      CANBT1 = 0x06;
+    case 125000: // TQ=0.500
+      CANBT1 = 0x0E;
       CANBT2 = 0x0C;
       CANBT3 = 0x37;
       break;
-    case 500000:
-      CANBT1 = 0x06;
-      CANBT2 = 0x04;
-      CANBT3 = 0x13;
-      break;
-    case 1000000:
-      CANBT1 = 0x02;
-      CANBT2 = 0x04;
-      CANBT3 = 0x13;
+    case 100000: // TQ=0.625
+      CANBT1 = 0x12;
+      CANBT2 = 0x0C;
+      CANBT3 = 0x37;
       break;
     default:
       return(0);


### PR DESCRIPTION
https://github.com/Atlantis-Specialist-Technologies/CAN485/pull/7 can be used to select a lower frequency in the IDE. Application code example:

```
void setup() {
    if(F_CPU == 8000000) clock_prescale_set(clock_div_2);
    canInit(500000);           
    Serial.begin(115200);
}
```